### PR TITLE
fix

### DIFF
--- a/src/components/layout/Header/style.scss
+++ b/src/components/layout/Header/style.scss
@@ -157,11 +157,12 @@
     cursor: pointer;
     padding: 0;
     transition: all $transition-base;
+    position: relative;
+    z-index: $z-modal + 10;
 
     @include responsive(lg) {
       display: none;
     }
-
     &--active {
       .header__menu-toggle-line {
         &:nth-child(1) {


### PR DESCRIPTION
The toggle button for closing the mobile menu is currently working but looks distorted. It’s an "X" icon, but it appears visually warped or unbalanced — like it’s stretched, rotated incorrectly, or not aligned properly.